### PR TITLE
feat: add provider management endpoints to openapi

### DIFF
--- a/packages/openapi/src/controllers/index.ts
+++ b/packages/openapi/src/controllers/index.ts
@@ -4,6 +4,7 @@ export * from './file.controller';
 export * from './message.controller';
 export * from './message-translations.controller';
 export * from './model.controller';
+export * from './provider.controller';
 export * from './role.controller';
 export * from './session.controller';
 export * from './session-group.controller';

--- a/packages/openapi/src/controllers/provider.controller.ts
+++ b/packages/openapi/src/controllers/provider.controller.ts
@@ -1,0 +1,96 @@
+import { Context } from 'hono';
+
+import { BaseController } from '../common/base.controller';
+import { ProviderService } from '../services/provider.service';
+import {
+  CreateProviderRequest,
+  DeleteProviderRequest,
+  GetProviderDetailRequest,
+  ProviderListQuery,
+  ProviderIdParam,
+  UpdateProviderRequest,
+  UpdateProviderRequestBody,
+} from '../types/provider.type';
+
+/**
+ * Provider 控制器，负责处理 Provider 相关的 HTTP 请求
+ */
+export class ProviderController extends BaseController {
+  async handleGetProviders(c: Context): Promise<Response> {
+    try {
+      const query = this.getQuery<ProviderListQuery>(c);
+      const db = await this.getDatabase();
+      const providerService = new ProviderService(db, this.getUserId(c));
+
+      const result = await providerService.getProviders(query);
+
+      return this.success(c, result, '获取 Provider 列表成功');
+    } catch (error) {
+      return this.handleError(c, error);
+    }
+  }
+
+  async handleGetProvider(c: Context): Promise<Response> {
+    try {
+      const { id } = this.getParams<ProviderIdParam>(c);
+      const request: GetProviderDetailRequest = { id };
+
+      const db = await this.getDatabase();
+      const providerService = new ProviderService(db, this.getUserId(c));
+      const provider = await providerService.getProviderDetail(request);
+
+      return this.success(c, provider, '获取 Provider 详情成功');
+    } catch (error) {
+      return this.handleError(c, error);
+    }
+  }
+
+  async handleCreateProvider(c: Context): Promise<Response> {
+    try {
+      const body = await this.getBody<CreateProviderRequest>(c);
+
+      const db = await this.getDatabase();
+      const providerService = new ProviderService(db, this.getUserId(c));
+      const created = await providerService.createProvider(body);
+
+      return this.success(c, created, '创建 Provider 成功');
+    } catch (error) {
+      return this.handleError(c, error);
+    }
+  }
+
+  async handleUpdateProvider(c: Context): Promise<Response> {
+    try {
+      const { id } = this.getParams<ProviderIdParam>(c);
+      const body = await this.getBody<UpdateProviderRequestBody>(c);
+
+      const request: UpdateProviderRequest = {
+        ...body,
+        id,
+      };
+
+      const db = await this.getDatabase();
+      const providerService = new ProviderService(db, this.getUserId(c));
+      const updated = await providerService.updateProvider(request);
+
+      return this.success(c, updated, '更新 Provider 成功');
+    } catch (error) {
+      return this.handleError(c, error);
+    }
+  }
+
+  async handleDeleteProvider(c: Context): Promise<Response> {
+    try {
+      const { id } = this.getParams<ProviderIdParam>(c);
+      const request: DeleteProviderRequest = { id };
+
+      const db = await this.getDatabase();
+      const providerService = new ProviderService(db, this.getUserId(c));
+      await providerService.deleteProvider(request);
+
+      return this.success(c, null, '删除 Provider 成功');
+    } catch (error) {
+      return this.handleError(c, error);
+    }
+  }
+}

--- a/packages/openapi/src/routes/index.ts
+++ b/packages/openapi/src/routes/index.ts
@@ -4,6 +4,7 @@ import FileRoutes from './files.route';
 import MessageTranslationsRoutes from './message-translations.route';
 import MessageRoutes from './message.route';
 import ModelRoutes from './models.route';
+import ProviderRoutes from './providers.route';
 import RolesRoutes from './roles.route';
 import SessionGroupRoutes from './session-groups.route';
 import SessionRoutes from './sessions.route';
@@ -17,6 +18,7 @@ export default {
   'message-translations': MessageTranslationsRoutes,
   'messages': MessageRoutes,
   'models': ModelRoutes,
+  'providers': ProviderRoutes,
   'roles': RolesRoutes,
   'session-groups': SessionGroupRoutes,
   'sessions': SessionRoutes,

--- a/packages/openapi/src/routes/providers.route.ts
+++ b/packages/openapi/src/routes/providers.route.ts
@@ -1,0 +1,74 @@
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+
+import { getAllScopePermissions } from '@/utils/rbac';
+
+import { ProviderController } from '../controllers/provider.controller';
+import { requireAuth } from '../middleware/auth';
+import { requireAnyPermission } from '../middleware/permission-check';
+import {
+  CreateProviderRequestSchema,
+  ProviderIdParamSchema,
+  ProviderListQuerySchema,
+  UpdateProviderRequestSchema,
+} from '../types/provider.type';
+
+const ProviderRoutes = new Hono();
+
+ProviderRoutes.get(
+  '/',
+  requireAuth,
+  requireAnyPermission(getAllScopePermissions('AI_PROVIDER_READ'), '您没有权限查看 Provider 列表'),
+  zValidator('query', ProviderListQuerySchema),
+  (c) => {
+    const controller = new ProviderController();
+    return controller.handleGetProviders(c);
+  },
+);
+
+ProviderRoutes.get(
+  '/:id',
+  requireAuth,
+  requireAnyPermission(getAllScopePermissions('AI_PROVIDER_READ'), '您没有权限查看 Provider 详情'),
+  zValidator('param', ProviderIdParamSchema),
+  (c) => {
+    const controller = new ProviderController();
+    return controller.handleGetProvider(c);
+  },
+);
+
+ProviderRoutes.post(
+  '/',
+  requireAuth,
+  requireAnyPermission(getAllScopePermissions('AI_PROVIDER_CREATE'), '您没有权限创建 Provider'),
+  zValidator('json', CreateProviderRequestSchema),
+  (c) => {
+    const controller = new ProviderController();
+    return controller.handleCreateProvider(c);
+  },
+);
+
+ProviderRoutes.patch(
+  '/:id',
+  requireAuth,
+  requireAnyPermission(getAllScopePermissions('AI_PROVIDER_UPDATE'), '您没有权限更新 Provider'),
+  zValidator('param', ProviderIdParamSchema),
+  zValidator('json', UpdateProviderRequestSchema),
+  (c) => {
+    const controller = new ProviderController();
+    return controller.handleUpdateProvider(c);
+  },
+);
+
+ProviderRoutes.delete(
+  '/:id',
+  requireAuth,
+  requireAnyPermission(getAllScopePermissions('AI_PROVIDER_DELETE'), '您没有权限删除 Provider'),
+  zValidator('param', ProviderIdParamSchema),
+  (c) => {
+    const controller = new ProviderController();
+    return controller.handleDeleteProvider(c);
+  },
+);
+
+export default ProviderRoutes;

--- a/packages/openapi/src/services/index.ts
+++ b/packages/openapi/src/services/index.ts
@@ -4,6 +4,7 @@ export * from './file.service';
 export * from './message.service';
 export * from './message-translations.service';
 export * from './model.service';
+export * from './provider.service';
 export * from './role.service';
 export * from './session.service';
 export * from './session-group.service';

--- a/packages/openapi/src/services/provider.service.ts
+++ b/packages/openapi/src/services/provider.service.ts
@@ -1,0 +1,380 @@
+import { and, asc, count, desc, eq, ilike, or } from 'drizzle-orm';
+
+import { aiModels, aiProviders, AiProviderSelectItem } from '@/database/schemas';
+import { LobeChatDatabase } from '@/database/type';
+import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
+
+import { BaseService } from '../common/base.service';
+import { processPaginationConditions } from '../helpers/pagination';
+import { ServiceResult } from '../types';
+import {
+  CreateProviderRequest,
+  DeleteProviderRequest,
+  GetProviderDetailRequest,
+  GetProvidersResponse,
+  ProviderDetailResponse,
+  ProviderKeyVaults,
+  ProviderListQuery,
+  ProviderRecord,
+  UpdateProviderRequest,
+} from '../types/provider.type';
+
+/**
+ * Provider 服务实现类，负责处理 AI Provider 的业务逻辑
+ */
+export class ProviderService extends BaseService {
+  private gateKeeperPromise: Promise<KeyVaultsGateKeeper> | null = null;
+
+  constructor(db: LobeChatDatabase, userId: string | null) {
+    super(db, userId);
+  }
+
+  private async getGateKeeper(): Promise<KeyVaultsGateKeeper> {
+    if (!this.gateKeeperPromise) {
+      this.gateKeeperPromise = KeyVaultsGateKeeper.initWithEnvKey();
+    }
+
+    return this.gateKeeperPromise;
+  }
+
+  private async encryptKeyVaults(
+    keyVaults: ProviderKeyVaults | null | undefined,
+  ): Promise<string | null | undefined> {
+    if (keyVaults === undefined) return undefined;
+    if (keyVaults === null) return null;
+
+    const gateKeeper = await this.getGateKeeper();
+
+    return gateKeeper.encrypt(JSON.stringify(keyVaults));
+  }
+
+  private async decryptKeyVaults(encrypted: string | null): Promise<ProviderKeyVaults | undefined> {
+    if (!encrypted) return undefined;
+
+    try {
+      const gateKeeper = await this.getGateKeeper();
+      const { plaintext, wasAuthentic } = await gateKeeper.decrypt(encrypted);
+
+      if (!wasAuthentic || !plaintext) return undefined;
+
+      const parsed = JSON.parse(plaintext);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as ProviderKeyVaults;
+      }
+
+      return undefined;
+    } catch (error) {
+      this.log('warn', '解密 Provider KeyVaults 失败', {
+        error,
+      });
+      return undefined;
+    }
+  }
+
+  private transformProviderRecord(provider: AiProviderSelectItem): ProviderRecord {
+    const { keyVaults: _ignored, fetchOnClient, ...rest } = provider;
+
+    return {
+      ...rest,
+      fetchOnClient: typeof fetchOnClient === 'boolean' ? fetchOnClient : undefined,
+    };
+  }
+
+  async getProviders(request: ProviderListQuery = {}): ServiceResult<GetProvidersResponse> {
+    this.log('info', '获取 Provider 列表', {
+      request,
+      userId: this.userId,
+    });
+
+    try {
+      const permissionResult = await this.resolveOperationPermission('AI_PROVIDER_READ');
+
+      if (!permissionResult.isPermitted) {
+        throw this.createAuthorizationError(permissionResult.message || '无权访问 Provider 列表');
+      }
+
+      const conditions = [] as any[];
+
+      if (permissionResult.condition?.userId) {
+        conditions.push(eq(aiProviders.userId, permissionResult.condition.userId));
+      }
+
+      if (request.keyword) {
+        conditions.push(
+          or(
+            ilike(aiProviders.id, `%${request.keyword}%`),
+            ilike(aiProviders.name, `%${request.keyword}%`),
+            ilike(aiProviders.description, `%${request.keyword}%`),
+          ),
+        );
+      }
+
+      if (typeof request.enabled === 'boolean') {
+        conditions.push(eq(aiProviders.enabled, request.enabled));
+      }
+
+      if (request.source) {
+        conditions.push(eq(aiProviders.source, request.source));
+      }
+
+      const whereCondition =
+        conditions.length > 1 ? and(...conditions) : conditions[0] ?? undefined;
+
+      const { limit, offset } = processPaginationConditions(request);
+
+      const [providers, totalResult] = await Promise.all([
+        this.db.query.aiProviders.findMany({
+          limit,
+          offset,
+          orderBy: [asc(aiProviders.sort), desc(aiProviders.updatedAt)],
+          where: whereCondition,
+        }),
+        this.db.select({ count: count() }).from(aiProviders).where(whereCondition),
+      ]);
+
+      const sanitizedProviders = providers.map((provider) => this.transformProviderRecord(provider));
+
+      return {
+        providers: sanitizedProviders,
+        total: totalResult[0]?.count ?? 0,
+      };
+    } catch (error) {
+      this.handleServiceError(error, '获取 Provider 列表');
+    }
+  }
+
+  async getProviderDetail(request: GetProviderDetailRequest): ServiceResult<ProviderDetailResponse> {
+    this.log('info', '获取 Provider 详情', {
+      id: request.id,
+      userId: this.userId,
+    });
+
+    try {
+      const permissionResult = await this.resolveOperationPermission('AI_PROVIDER_READ', {
+        targetProviderId: request.id,
+      });
+
+      if (!permissionResult.isPermitted) {
+        throw this.createAuthorizationError(permissionResult.message || '无权访问 Provider 详情');
+      }
+
+      const whereConditions = [eq(aiProviders.id, request.id)];
+
+      if (permissionResult.condition?.userId) {
+        whereConditions.push(eq(aiProviders.userId, permissionResult.condition.userId));
+      }
+
+      const whereCondition =
+        whereConditions.length > 1 ? and(...whereConditions) : whereConditions[0];
+
+      const provider = await this.db.query.aiProviders.findFirst({
+        where: whereCondition,
+      });
+
+      if (!provider) {
+        throw this.createNotFoundError(`未找到 Provider: ${request.id}`);
+      }
+
+      const sanitized = this.transformProviderRecord(provider);
+      const keyVaults = await this.decryptKeyVaults(provider.keyVaults);
+
+      return {
+        ...sanitized,
+        keyVaults,
+      };
+    } catch (error) {
+      this.handleServiceError(error, '获取 Provider 详情');
+    }
+  }
+
+  async createProvider(request: CreateProviderRequest): ServiceResult<ProviderDetailResponse> {
+    this.log('info', '创建 Provider', {
+      id: request.id,
+      userId: this.userId,
+    });
+
+    try {
+      if (!this.userId) {
+        throw this.createAuthError('用户未登录');
+      }
+
+      const permissionResult = await this.resolveOperationPermission('AI_PROVIDER_CREATE');
+
+      if (!permissionResult.isPermitted) {
+        throw this.createAuthorizationError(permissionResult.message || '无权创建 Provider');
+      }
+
+      const ownerId = permissionResult.condition?.userId ?? this.userId;
+
+      const existed = await this.db.query.aiProviders.findFirst({
+        where: and(eq(aiProviders.id, request.id), eq(aiProviders.userId, ownerId)),
+      });
+
+      if (existed) {
+        throw this.createBusinessError(`Provider "${request.id}" 已存在`);
+      }
+
+      const encryptedKeyVaults = await this.encryptKeyVaults(request.keyVaults);
+      const now = new Date();
+
+      const [createdProvider] = await this.db
+        .insert(aiProviders)
+        .values({
+          checkModel: request.checkModel ?? null,
+          config: request.config ?? {},
+          createdAt: now,
+          description: request.description ?? null,
+          enabled: request.enabled ?? true,
+          fetchOnClient: request.fetchOnClient ?? null,
+          id: request.id,
+          keyVaults: encryptedKeyVaults ?? null,
+          logo: request.logo ?? null,
+          name: request.name ?? null,
+          settings: request.settings ?? {},
+          sort: request.sort ?? null,
+          source: request.source,
+          updatedAt: now,
+          userId: ownerId,
+        })
+        .returning();
+
+      const sanitized = this.transformProviderRecord(createdProvider);
+
+      return {
+        ...sanitized,
+        keyVaults: request.keyVaults,
+      };
+    } catch (error) {
+      this.handleServiceError(error, '创建 Provider');
+    }
+  }
+
+  async updateProvider(request: UpdateProviderRequest): ServiceResult<ProviderDetailResponse> {
+    this.log('info', '更新 Provider', {
+      id: request.id,
+      userId: this.userId,
+    });
+
+    try {
+      const permissionResult = await this.resolveOperationPermission('AI_PROVIDER_UPDATE', {
+        targetProviderId: request.id,
+      });
+
+      if (!permissionResult.isPermitted) {
+        throw this.createAuthorizationError(permissionResult.message || '无权更新 Provider');
+      }
+
+      const whereConditions = [eq(aiProviders.id, request.id)];
+
+      if (permissionResult.condition?.userId) {
+        whereConditions.push(eq(aiProviders.userId, permissionResult.condition.userId));
+      }
+
+      const whereCondition =
+        whereConditions.length > 1 ? and(...whereConditions) : whereConditions[0];
+
+      const existing = await this.db.query.aiProviders.findFirst({
+        where: whereCondition,
+      });
+
+      if (!existing) {
+        throw this.createNotFoundError(`未找到 Provider: ${request.id}`);
+      }
+
+      const encryptedKeyVaults = await this.encryptKeyVaults(request.keyVaults);
+
+      const updateData: Partial<typeof aiProviders.$inferInsert> = {
+        updatedAt: new Date(),
+      };
+
+      if (request.name !== undefined) updateData.name = request.name ?? null;
+      if (request.description !== undefined) updateData.description = request.description ?? null;
+      if (request.logo !== undefined) updateData.logo = request.logo ?? null;
+      if (request.checkModel !== undefined) updateData.checkModel = request.checkModel ?? null;
+      if (request.fetchOnClient !== undefined) updateData.fetchOnClient = request.fetchOnClient;
+      if (request.enabled !== undefined) updateData.enabled = request.enabled;
+      if (request.sort !== undefined) updateData.sort = request.sort ?? null;
+      if (request.source !== undefined) updateData.source = request.source;
+      if (request.settings !== undefined) updateData.settings = request.settings ?? {};
+      if (request.config !== undefined) updateData.config = request.config ?? {};
+      if (encryptedKeyVaults !== undefined) updateData.keyVaults = encryptedKeyVaults;
+
+      const [updatedProvider] = await this.db
+        .update(aiProviders)
+        .set(updateData)
+        .where(whereCondition)
+        .returning();
+
+      if (!updatedProvider) {
+        throw this.createBusinessError('更新 Provider 失败');
+      }
+
+      const sanitized = this.transformProviderRecord(updatedProvider);
+      const keyVaults =
+        request.keyVaults !== undefined
+          ? request.keyVaults ?? undefined
+          : await this.decryptKeyVaults(updatedProvider.keyVaults);
+
+      return {
+        ...sanitized,
+        keyVaults,
+      };
+    } catch (error) {
+      this.handleServiceError(error, '更新 Provider');
+    }
+  }
+
+  async deleteProvider(request: DeleteProviderRequest): ServiceResult<void> {
+    this.log('info', '删除 Provider', {
+      id: request.id,
+      userId: this.userId,
+    });
+
+    try {
+      const permissionResult = await this.resolveOperationPermission('AI_PROVIDER_DELETE', {
+        targetProviderId: request.id,
+      });
+
+      if (!permissionResult.isPermitted) {
+        throw this.createAuthorizationError(permissionResult.message || '无权删除 Provider');
+      }
+
+      const whereConditions = [eq(aiProviders.id, request.id)];
+
+      if (permissionResult.condition?.userId) {
+        whereConditions.push(eq(aiProviders.userId, permissionResult.condition.userId));
+      }
+
+      const providerWhere =
+        whereConditions.length > 1 ? and(...whereConditions) : whereConditions[0]!;
+
+      const provider = await this.db.query.aiProviders.findFirst({
+        where: providerWhere,
+      });
+
+      if (!provider) {
+        throw this.createNotFoundError(`未找到 Provider: ${request.id}`);
+      }
+
+      await this.db.transaction(async (tx) => {
+        const modelConditions = [eq(aiModels.providerId, request.id)];
+
+        if (permissionResult.condition?.userId) {
+          modelConditions.push(eq(aiModels.userId, permissionResult.condition.userId));
+        }
+
+        const modelWhere =
+          modelConditions.length > 1 ? and(...modelConditions) : modelConditions[0]!;
+
+        await tx.delete(aiModels).where(modelWhere);
+        await tx.delete(aiProviders).where(providerWhere);
+      });
+
+      this.log('info', 'Provider 删除成功', {
+        id: request.id,
+      });
+    } catch (error) {
+      this.handleServiceError(error, '删除 Provider');
+    }
+  }
+}

--- a/packages/openapi/src/types/index.ts
+++ b/packages/openapi/src/types/index.ts
@@ -59,6 +59,7 @@ export * from './file.type';
 export * from './message.type';
 export * from './message-translations.type';
 export * from './model.type';
+export * from './provider.type';
 export * from './role.type';
 export * from './session.type';
 export * from './topic.type';

--- a/packages/openapi/src/types/provider.type.ts
+++ b/packages/openapi/src/types/provider.type.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+
+import { AiProviderSelectItem } from '@/database/schemas';
+import { AiProviderConfig, AiProviderSettings, AiProviderSourceType } from '@/types/aiProvider';
+
+import { IPaginationQuery, PaginationQueryResponse, PaginationQuerySchema } from './common.type';
+
+// ==================== Provider Common Types ====================
+
+export type ProviderKeyVaults = Record<string, string | undefined>;
+
+export type ProviderRecord = Omit<AiProviderSelectItem, 'keyVaults'>;
+
+export interface ProviderDetailResponse extends ProviderRecord {
+  keyVaults?: ProviderKeyVaults;
+}
+
+export type GetProvidersResponse = PaginationQueryResponse<{
+  providers: ProviderRecord[];
+}>;
+
+export interface GetProviderDetailRequest {
+  id: string;
+}
+
+export interface DeleteProviderRequest {
+  id: string;
+}
+
+// ==================== Provider Query Types ====================
+
+export interface ProviderListQuery extends IPaginationQuery {
+  enabled?: boolean;
+  source?: AiProviderSourceType;
+}
+
+const EnabledQuerySchema = z.preprocess(
+  (val) => {
+    if (typeof val === 'boolean') return val;
+    if (val === undefined || val === null || val === '') return undefined;
+    if (typeof val === 'string') {
+      const normalized = val.trim().toLowerCase();
+      if (normalized === 'true' || normalized === '1') return true;
+      if (normalized === 'false' || normalized === '0') return false;
+    }
+
+    return undefined;
+  },
+  z.boolean().optional(),
+);
+
+export const ProviderListQuerySchema = PaginationQuerySchema.extend({
+  enabled: EnabledQuerySchema,
+  source: z.enum(['builtin', 'custom']).optional(),
+}).passthrough();
+
+export type ProviderListQuerySchemaType = z.infer<typeof ProviderListQuerySchema>;
+
+// ==================== Provider Mutation Schemas ====================
+
+const ProviderPayloadBaseSchema = z.object({
+  checkModel: z.string().nullable().optional(),
+  config: z.record(z.unknown()).optional(),
+  description: z.string().nullable().optional(),
+  enabled: z.boolean().optional(),
+  fetchOnClient: z.boolean().nullable().optional(),
+  keyVaults: z.record(z.string()).optional(),
+  logo: z.string().nullable().optional(),
+  name: z.string().min(1, 'Provider 名称不能为空').nullable().optional(),
+  settings: z.record(z.unknown()).optional(),
+  sort: z.number().int().nullable().optional(),
+  source: z.enum(['builtin', 'custom']).optional(),
+});
+
+export const CreateProviderRequestSchema = ProviderPayloadBaseSchema.extend({
+  id: z.string().min(1, 'Provider ID 不能为空'),
+  source: z.enum(['builtin', 'custom']),
+});
+
+export const UpdateProviderRequestSchema = ProviderPayloadBaseSchema.extend({
+  keyVaults: z.record(z.string()).nullable().optional(),
+});
+
+export type CreateProviderRequestSchemaType = z.infer<typeof CreateProviderRequestSchema>;
+export type UpdateProviderRequestSchemaType = z.infer<typeof UpdateProviderRequestSchema>;
+
+export interface CreateProviderRequest
+  extends Omit<CreateProviderRequestSchemaType, 'config' | 'settings' | 'keyVaults'> {
+  config?: AiProviderConfig;
+  settings?: AiProviderSettings;
+  keyVaults?: ProviderKeyVaults;
+}
+
+export type UpdateProviderRequestBody = Omit<
+  UpdateProviderRequestSchemaType,
+  'config' | 'settings' | 'keyVaults'
+> & {
+  config?: AiProviderConfig;
+  settings?: AiProviderSettings;
+  keyVaults?: ProviderKeyVaults | null;
+};
+
+export interface UpdateProviderRequest extends UpdateProviderRequestBody {
+  id: string;
+}
+
+export interface CreateProviderResponse extends ProviderDetailResponse {}
+export interface UpdateProviderResponse extends ProviderDetailResponse {}
+
+// ==================== Provider Param Schemas ====================
+
+export const ProviderIdParamSchema = z.object({
+  id: z.string().min(1, 'Provider ID 不能为空'),
+});
+
+export type ProviderIdParam = z.infer<typeof ProviderIdParamSchema>;


### PR DESCRIPTION
## Summary
- introduce provider-specific types and schemas for queries and mutations
- implement provider service, controller, and routes with RBAC checks and key vault handling
- expose the new provider module through the existing index exports

## Testing
- bun run type-check *(fails: tsgo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c6327ee48328b7b7ab53edb843e8