### PR TITLE
Adjust knowledge base empty state for read-only view

### DIFF
--- a/src/features/FileManager/FileList/EmptyStatus.tsx
+++ b/src/features/FileManager/FileList/EmptyStatus.tsx
@@ -81,6 +81,15 @@ const EmptyStatus = ({ showKnowledgeBase, knowledgeBaseId }: EmptyStatusProps) =
   const showUploadActions = !isReadOnly;
   const showActions = showKnowledgeBaseAction || showUploadActions;
 
+  if (!showActions) {
+    return (
+      <Center gap={12} height={'100%'} style={{ paddingBottom: 100 }} width={'100%'}>
+        <FileTypeIcon size={ICON_SIZE} type={'folder'} />
+        <Text type={'secondary'}>{t('FileManager.emptyStatus.knowledgeBaseEmpty')}</Text>
+      </Center>
+    );
+  }
+
   return (
     <Center gap={24} height={'100%'} style={{ paddingBottom: 100 }} width={'100%'}>
       <Flexbox justify={'center'} style={{ textAlign: 'center' }}>

--- a/src/locales/default/components.ts
+++ b/src/locales/default/components.ts
@@ -41,6 +41,7 @@ export default {
         folder: '上传文件夹',
         knowledgeBase: '新建知识库',
       },
+      knowledgeBaseEmpty: '当前知识库暂无内容',
       or: '或者',
       title: '将文件或文件夹拖到这里',
     },


### PR DESCRIPTION
## Summary
- remove manual edits to generated locale JSON files and rely on src/locales as the source of truth for the empty-state text
- keep the knowledge base empty-state copy defined in src/locales for downstream translation scripts

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d12d22c88328bbd777dc088e6a95)