### PR TITLE
Refine AI provider permissions hook

### DIFF
--- a/src/app/[variants]/(main)/settings/hooks/useCategory.tsx
+++ b/src/app/[variants]/(main)/settings/hooks/useCategory.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { MenuProps } from '@/components/Menu';
 import { isDeprecatedEdition, isDesktop } from '@/const/version';
+import { useAIProviderPermissions } from '@/hooks/useRbacPermissions';
 import { SettingsTabs } from '@/store/global/initialState';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
@@ -23,6 +24,8 @@ export const useCategory = () => {
   const { t } = useTranslation('setting');
   const mobile = useServerConfigStore((s) => s.isMobile);
   const { showLLM, enableSTT, hideDocs } = useServerConfigStore(featureFlagsSelectors);
+  const { showProviderMenu, isRbacReady } = useAIProviderPermissions();
+  const allowProviderMenu = isRbacReady ? showProviderMenu : true;
 
   const cateItems: MenuProps['items'] = useMemo(
     () =>
@@ -46,6 +49,7 @@ export const useCategory = () => {
           type: 'divider',
         },
         showLLM &&
+          allowProviderMenu &&
           // TODO: Remove /llm when v2.0
           (isDeprecatedEdition
             ? {
@@ -92,7 +96,7 @@ export const useCategory = () => {
           label: t('tab.about'),
         },
       ].filter(Boolean) as MenuProps['items'],
-    [t, showLLM, enableSTT, hideDocs, mobile],
+    [t, showLLM, enableSTT, hideDocs, mobile, allowProviderMenu],
   );
 
   return cateItems;

--- a/src/app/[variants]/(main)/settings/provider/(list)/ProviderGrid/EnableSwitch.tsx
+++ b/src/app/[variants]/(main)/settings/provider/(list)/ProviderGrid/EnableSwitch.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 
 import InstantSwitch from '@/components/InstantSwitch';
+import { useAIProviderPermissions } from '@/hooks/useRbacPermissions';
 import { useAiInfraStore } from '@/store/aiInfra';
 
 interface SwitchProps {
@@ -11,12 +12,14 @@ interface SwitchProps {
 
 const Switch = ({ id, Component, enabled }: SwitchProps) => {
   const [toggleProviderEnabled] = useAiInfraStore((s) => [s.toggleProviderEnabled]);
+  const { canUpdate } = useAIProviderPermissions();
 
   // slot for cloud
   if (Component) return <Component enabled={enabled} id={id} />;
 
   return (
     <InstantSwitch
+      disabled={!canUpdate}
       enabled={enabled}
       onChange={async (checked) => {
         await toggleProviderEnabled(id, checked);

--- a/src/app/[variants]/(main)/settings/provider/ProviderMenu/AddNew.tsx
+++ b/src/app/[variants]/(main)/settings/provider/ProviderMenu/AddNew.tsx
@@ -5,11 +5,16 @@ import { PlusIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAIProviderPermissions } from '@/hooks/useRbacPermissions';
+
 import CreateNewProvider from '../features/CreateNewProvider';
 
 const AddNewProvider = () => {
   const { t } = useTranslation('modelProvider');
   const [open, setOpen] = useState(false);
+  const { canCreate } = useAIProviderPermissions();
+
+  if (!canCreate) return null;
 
   return (
     <>

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/DisabledModels.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/DisabledModels.tsx
@@ -12,9 +12,10 @@ import ModelItem from './ModelItem';
 
 interface DisabledModelsProps {
   activeTab: string;
+  canUpdate: boolean;
 }
 
-const DisabledModels = memo<DisabledModelsProps>(({ activeTab }) => {
+const DisabledModels = memo<DisabledModelsProps>(({ activeTab, canUpdate }) => {
   const { t } = useTranslation('modelProvider');
 
   const [showMore, setShowMore] = useState(false);
@@ -35,7 +36,7 @@ const DisabledModels = memo<DisabledModelsProps>(({ activeTab }) => {
           {t('providerModels.list.disabled')}
         </Text>
         {displayModels.map((item) => (
-          <ModelItem {...item} key={item.id} />
+          <ModelItem disabled={!canUpdate} {...item} key={item.id} />
         ))}
         {!showMore && filteredDisabledModels.length > 10 && (
           <Button

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/EnabledModelList/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/EnabledModelList/index.tsx
@@ -13,9 +13,10 @@ import SortModelModal from '../SortModelModal';
 
 interface EnabledModelListProps {
   activeTab: string;
+  canUpdate: boolean;
 }
 
-const EnabledModelList = ({ activeTab }: EnabledModelListProps) => {
+const EnabledModelList = ({ canUpdate, activeTab }: EnabledModelListProps) => {
   const { t } = useTranslation('modelProvider');
 
   const enabledModels = useAiInfraStore(aiModelSelectors.enabledAiProviderModelList, isEqual);
@@ -38,7 +39,7 @@ const EnabledModelList = ({ activeTab }: EnabledModelListProps) => {
         <Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
           {t('providerModels.list.enabled')}
         </Text>
-        {!isEmpty && (
+        {!isEmpty && canUpdate && (
           <Flexbox horizontal>
             <ActionIcon
               icon={ToggleLeft}
@@ -92,7 +93,15 @@ const EnabledModelList = ({ activeTab }: EnabledModelListProps) => {
         <Flexbox gap={2}>
           {filteredModels.map(({ displayName, id, ...res }) => {
             const label = displayName || id;
-            return <ModelItem displayName={label as string} id={id as string} key={id} {...res} />;
+            return (
+              <ModelItem
+                disabled={!canUpdate}
+                displayName={label as string}
+                id={id as string}
+                key={id}
+                {...res}
+              />
+            );
           })}
         </Flexbox>
       )}

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelItem.tsx
@@ -56,6 +56,7 @@ export const useStyles = createStyles(({ css, token, cx }) => {
 });
 
 interface ModelItemProps extends AiProviderModelListItem {
+  disabled?: boolean;
   enabled: boolean;
   id: string;
   isAzure?: boolean;
@@ -75,6 +76,7 @@ const ModelItem = memo<ModelItemProps>(
     contextWindowTokens,
     abilities,
     type,
+    disabled,
   }) => {
     const { styles } = useStyles();
     const { t } = useTranslation(['modelProvider', 'components', 'models', 'common']);
@@ -202,7 +204,7 @@ const ModelItem = memo<ModelItemProps>(
           </Flexbox>
         </Flexbox>
         <Flexbox align={'center'} gap={4} horizontal>
-          {modelEditable && (
+          {modelEditable && !disabled && (
             <Flexbox className={styles.config} horizontal style={{ opacity: 1 }}>
               <ActionIcon
                 icon={LucidePencil}
@@ -240,6 +242,7 @@ const ModelItem = memo<ModelItemProps>(
           )}
           <Switch
             checked={checked}
+            disabled={!modelEditable || disabled}
             loading={isModelLoading}
             onChange={async (e) => {
               setChecked(e);
@@ -267,7 +270,7 @@ const ModelItem = memo<ModelItemProps>(
               <Tag onClick={copyModelId} style={{ cursor: 'pointer', marginRight: 0 }}>
                 {id}
               </Tag>
-              {modelEditable && (
+              {modelEditable && !disabled && (
                 <Flexbox className={styles.config} horizontal>
                   <ActionIcon
                     icon={LucidePencil}
@@ -331,6 +334,7 @@ const ModelItem = memo<ModelItemProps>(
           {/*)}*/}
           <Switch
             checked={checked}
+            disabled={!modelEditable || disabled}
             loading={isModelLoading}
             onChange={async (e) => {
               setChecked(e);

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { useAIProviderPermissions } from '@/hooks/useRbacPermissions';
 import { useAiInfraStore } from '@/store/aiInfra';
 import { aiModelSelectors } from '@/store/aiInfra/selectors';
 
@@ -45,6 +46,7 @@ const ModelTitle = memo<ModelFetcherProps>(
     ]);
 
     const { isLoading } = useFetchAiProviderModels(provider);
+    const { canUpdate } = useAIProviderPermissions();
 
     const [fetchRemoteModelsLoading, setFetchRemoteModelsLoading] = useState(false);
     const [clearRemoteModelsLoading, setClearRemoteModelsLoading] = useState(false);
@@ -77,7 +79,7 @@ const ModelTitle = memo<ModelFetcherProps>(
               <Text style={{ fontSize: 12 }} type={'secondary'}>
                 <div style={{ display: 'flex', lineHeight: '24px' }}>
                   {t('providerModels.list.total', { count: totalModels })}
-                  {hasRemoteModels && (
+                  {hasRemoteModels && canUpdate && (
                     <ActionIcon
                       icon={CircleX}
                       loading={clearRemoteModelsLoading}
@@ -106,62 +108,66 @@ const ModelTitle = memo<ModelFetcherProps>(
                   value={searchKeyword}
                 />
               )}
-              <Space.Compact>
-                {showModelFetcher && (
-                  <Button
-                    icon={LucideRefreshCcwDot}
-                    loading={fetchRemoteModelsLoading}
-                    onClick={async () => {
-                      setFetchRemoteModelsLoading(true);
-                      try {
-                        await fetchRemoteModelList(provider);
-                      } catch (e) {
-                        console.error(e);
-                      }
-                      setFetchRemoteModelsLoading(false);
-                    }}
-                    size={'small'}
-                  >
-                    {fetchRemoteModelsLoading
-                      ? t('providerModels.list.fetcher.fetching')
-                      : t('providerModels.list.fetcher.fetch')}
-                  </Button>
-                )}
-                {showAddNewModel && (
-                  <>
+              {canUpdate && (
+                <Space.Compact>
+                  {showModelFetcher && (
                     <Button
-                      icon={PlusIcon}
-                      onClick={() => {
-                        setShowModal(true);
+                      icon={LucideRefreshCcwDot}
+                      loading={fetchRemoteModelsLoading}
+                      onClick={async () => {
+                        setFetchRemoteModelsLoading(true);
+                        try {
+                          await fetchRemoteModelList(provider);
+                        } catch (e) {
+                          console.error(e);
+                        }
+                        setFetchRemoteModelsLoading(false);
                       }}
                       size={'small'}
-                    />
-                    <CreateNewModelModal open={showModal} setOpen={setShowModal} />
-                  </>
-                )}
-                <Dropdown
-                  menu={{
-                    items: [
-                      {
-                        key: 'reset',
-                        label: t('providerModels.list.resetAll.title'),
-                        onClick: async () => {
-                          modal.confirm({
-                            content: t('providerModels.list.resetAll.conform'),
-                            onOk: async () => {
-                              await clearModelsByProvider(provider);
-                              message.success(t('providerModels.list.resetAll.success'));
+                    >
+                      {fetchRemoteModelsLoading
+                        ? t('providerModels.list.fetcher.fetching')
+                        : t('providerModels.list.fetcher.fetch')}
+                    </Button>
+                  )}
+                  {showAddNewModel && (
+                    <>
+                      <Button
+                        icon={PlusIcon}
+                        onClick={() => {
+                          setShowModal(true);
+                        }}
+                        size={'small'}
+                      />
+                      <CreateNewModelModal open={showModal} setOpen={setShowModal} />
+                    </>
+                  )}
+                  {canUpdate && (
+                    <Dropdown
+                      menu={{
+                        items: [
+                          {
+                            key: 'reset',
+                            label: t('providerModels.list.resetAll.title'),
+                            onClick: async () => {
+                              modal.confirm({
+                                content: t('providerModels.list.resetAll.conform'),
+                                onOk: async () => {
+                                  await clearModelsByProvider(provider);
+                                  message.success(t('providerModels.list.resetAll.success'));
+                                },
+                                title: t('providerModels.list.resetAll.title'),
+                              });
                             },
-                            title: t('providerModels.list.resetAll.title'),
-                          });
-                        },
-                      },
-                    ],
-                  }}
-                >
-                  <Button icon={EllipsisVertical} size={'small'} />
-                </Dropdown>
-              </Space.Compact>
+                          },
+                        ],
+                      }}
+                    >
+                      <Button icon={EllipsisVertical} size={'small'} />
+                    </Dropdown>
+                  )}
+                </Space.Compact>
+              )}
             </Flexbox>
           )}
         </Flexbox>

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/SearchResult.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/SearchResult.tsx
@@ -7,12 +7,15 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
+import { useAIProviderPermissions } from '@/hooks/useRbacPermissions';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 
 import ModelItem from './ModelItem';
 
 const SearchResult = memo(() => {
   const { t } = useTranslation('modelProvider');
+
+  const { canUpdate } = useAIProviderPermissions();
 
   const searchKeyword = useAiInfraStore((s) => s.modelSearchKeyword);
   const batchToggleAiModels = useAiInfraStore((s) => s.batchToggleAiModels);
@@ -28,7 +31,7 @@ const SearchResult = memo(() => {
         <Text style={{ fontSize: 12, marginTop: 8 }} type={'secondary'}>
           {t('providerModels.list.searchResult', { count: filteredModels.length })}
         </Text>
-        {!isEmpty && (
+        {!isEmpty && canUpdate && (
           <Flexbox horizontal>
             <ActionIcon
               icon={ToggleRightIcon}
@@ -55,7 +58,7 @@ const SearchResult = memo(() => {
       ) : (
         <Flexbox gap={4}>
           {filteredModels.map((item) => (
-            <ModelItem {...item} key={`${item.id}-${item.enabled}`} />
+            <ModelItem disabled={!canUpdate} {...item} key={`${item.id}-${item.enabled}`} />
           ))}
         </Flexbox>
       )}

--- a/src/app/[variants]/(main)/settings/provider/features/ModelList/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ModelList/index.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { Flexbox } from 'react-layout-kit';
 
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { useAIProviderPermissions } from '@/hooks/useRbacPermissions';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 
 import DisabledModels from './DisabledModels';
@@ -33,6 +34,8 @@ interface ContentProps {
 const Content = memo<ContentProps>(({ id }) => {
   const { t } = useTranslation('modelProvider');
   const [activeTab, setActiveTab] = useState('all');
+
+  const { canUpdate } = useAIProviderPermissions();
 
   const [isSearching, isEmpty, useFetchAiProviderModels] = useAiInfraStore((s) => [
     !!s.modelSearchKeyword,
@@ -132,8 +135,8 @@ const Content = memo<ContentProps>(({ id }) => {
         size="small"
         style={{ marginBottom: 12 }}
       />
-      <EnabledModelList activeTab={currentActiveTab} />
-      <DisabledModels activeTab={currentActiveTab} />
+      <EnabledModelList activeTab={currentActiveTab} canUpdate={canUpdate} />
+      <DisabledModels activeTab={currentActiveTab} canUpdate={canUpdate} />
     </Flexbox>
   );
 });

--- a/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/EnableSwitch.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/EnableSwitch.tsx
@@ -16,10 +16,11 @@ const useStyles = createStyles(({ css }) => ({
 
 interface SwitchProps {
   Component?: FC<{ id: string }>;
+  disabled?: boolean;
   id: string;
 }
 
-const Switch = ({ id, Component }: SwitchProps) => {
+const Switch = ({ id, Component, disabled }: SwitchProps) => {
   const { styles } = useStyles();
 
   const [toggleProviderEnabled, enabled, isLoading] = useAiInfraStore((s) => [
@@ -35,6 +36,7 @@ const Switch = ({ id, Component }: SwitchProps) => {
 
   return (
     <InstantSwitch
+      disabled={disabled}
       enabled={enabled}
       onChange={async (enabled) => {
         await toggleProviderEnabled(id as any, enabled);

--- a/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
+++ b/src/app/[variants]/(main)/settings/provider/features/ProviderConfig/index.tsx
@@ -24,6 +24,7 @@ import { FormInput, FormPassword } from '@/components/FormInput';
 import { FORM_STYLE } from '@/const/layoutTokens';
 import { AES_GCM_URL, BASE_PROVIDER_DOC_URL } from '@/const/url';
 import { isDesktop, isServerMode } from '@/const/version';
+import { useAIProviderPermissions } from '@/hooks/useRbacPermissions';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import {
   AiProviderDetailItem,
@@ -139,6 +140,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
       supportResponsesApi,
     } = settings || {};
     const { t } = useTranslation('modelProvider');
+    const { canUpdate } = useAIProviderPermissions();
     const [form] = Form.useForm();
     const { cx, styles, theme } = useStyles();
 
@@ -300,7 +302,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
       children: isLoading ? (
         <Skeleton.Button active className={styles.switchLoading} />
       ) : (
-        <Switch checked={isFetchOnClient} disabled={configUpdating} />
+        <Switch checked={isFetchOnClient} disabled={configUpdating || !canUpdate} />
       ),
       desc: t('providerModels.config.fetchOnClient.desc'),
       label: t('providerModels.config.fetchOnClient.title'),
@@ -364,8 +366,8 @@ const ProviderConfig = memo<ProviderConfigProps>(
         <Flexbox align={'center'} gap={8} horizontal>
           {extra}
 
-          {isCustom && <UpdateProviderInfo />}
-          <EnableSwitch id={id} />
+          {isCustom && canUpdate && <UpdateProviderInfo />}
+          <EnableSwitch disabled={!canUpdate} id={id} />
         </Flexbox>
       ),
       title: (
@@ -411,6 +413,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
     return (
       <Form
         className={cx(styles.form, className)}
+        disabled={!canUpdate}
         form={form}
         items={[model]}
         onValuesChange={(_, values) => {

--- a/src/components/InstantSwitch/index.tsx
+++ b/src/components/InstantSwitch/index.tsx
@@ -2,16 +2,18 @@ import { Switch, SwitchProps } from 'antd';
 import { memo, useState } from 'react';
 
 interface InstantSwitchProps {
+  disabled?: boolean;
   enabled: boolean;
   onChange: (enabled: boolean) => Promise<void>;
   size?: SwitchProps['size'];
 }
 
-const InstantSwitch = memo<InstantSwitchProps>(({ enabled, onChange, size }) => {
+const InstantSwitch = memo<InstantSwitchProps>(({ enabled, onChange, size, disabled }) => {
   const [value, setValue] = useState(enabled);
   const [loading, setLoading] = useState(false);
   return (
     <Switch
+      disabled={disabled}
       loading={loading}
       onChange={async (enabled) => {
         setLoading(true);

--- a/src/hooks/useRbacPermissions.ts
+++ b/src/hooks/useRbacPermissions.ts
@@ -17,6 +17,14 @@ interface CrudPermissionResult {
   isRbacReady: boolean;
 }
 
+interface AIProviderPermissions {
+  canCreate: boolean;
+  canDelete: boolean;
+  canUpdate: boolean;
+  isRbacReady: boolean;
+  showProviderMenu: boolean;
+}
+
 const createCrudPermissionHook = (keys: CrudPermissionKeys) => (): CrudPermissionResult =>
   useRbacStore((s) => {
     return {
@@ -38,3 +46,18 @@ export const useKnowledgeBasePermissions = createCrudPermissionHook({
   delete: 'KNOWLEDGE_BASE_DELETE',
   update: 'KNOWLEDGE_BASE_UPDATE',
 });
+
+export const useAIProviderPermissions = (): AIProviderPermissions => {
+  const basePermissions = createCrudPermissionHook({
+    create: 'AI_PROVIDER_CREATE',
+    delete: 'AI_PROVIDER_DELETE',
+    update: 'AI_PROVIDER_UPDATE',
+  })();
+  const { canCreate, canDelete, canUpdate } = basePermissions;
+
+  return {
+    ...basePermissions,
+    isRbacReady: basePermissions.isRbacReady,
+    showProviderMenu: canUpdate || canCreate || canDelete,
+  };
+};


### PR DESCRIPTION
## Summary
- adjust AI provider permissions hook to instantiate CRUD permissions inline
- keep derived read-only and menu flags based on create/delete/update access

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d0b0d4548328855df066be4db070)